### PR TITLE
[docs/requirements] refactored and extended README.md; bump flask-login to 0.6.3; added .gitkeep to instance-folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,8 @@ db.sqlite3
 db.sqlite3-journal
 
 # Flask stuff:
-instance/
+instance/*
+!instance/.gitkeep
 .webassets-cache
 
 # Scrapy stuff:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Eine Webapp die zur Verwaltung von Stammesmaterial verwendet werden kann. Entwic
 ## Installation mit Docker
 
 ### 1. Repository klonen
-```bash 
+```bash
 git clone https://github.com/dpsg-beckum/knotnpunkt.git
 cd knotnpunkt
 ```
@@ -47,7 +47,7 @@ Passwort: `admin`
 
 ## [WIP] Contributing
 
-+ Um zu erfahren, wie du bei knotnpunkt mithelfen kannst, lies bitte in der Datei [CONTRIBUTING.md](.github/CONTRIBUTING.md) nach 
++ Um zu erfahren, wie du bei knotnpunkt mithelfen kannst, lies bitte in der Datei [CONTRIBUTING.md](.github/CONTRIBUTING.md) nach
 + Um die Entwicker*innenversion zu starten, befolge diese Schritte:
 
 ### Voraussetzungen:
@@ -61,16 +61,23 @@ git clone https://github.com/dpsg-beckum/knotnpunkt.git
 cd knotnpunkt
 ```
 
-### 2. Python-Umgebung vorbereiten
+### 2. Python-Umgebung vorbereiten (Windows)
 ```PowerShell
 python -m venv .venv
 .venv/Scripts/activate
-pip install -r reqirements.txt
+pip install -r requirements.txt
+```
+
+### 2. Python-Umgebung vorbereiten (Linux)
+```PowerShell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
 ```
 
 ### 3. JavaScript-Bibliotheken installieren
 ```PowerShell
-yarn install 
+yarn install
 ```
 
 ### 5. Flask-Server starten

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cssselect2==0.7.0
 defusedxml==0.7.1
 Flask==2.3.2
 Flask-DB==0.3.2
-Flask-Login==0.6.2
+Flask-Login==0.6.3
 Flask-SQLAlchemy==3.0.2
 greenlet==2.0.1
 humanize==4.4.0


### PR DESCRIPTION
Hallo zusammen,
ich habe die Version von flask-login auf 0.6.3 geändert, da 0.6.2 mittlerweile inkompatibel mit der "werkzeug"-Library ist.
In der README.md habe ich einwenig aufgeräumt und eine Info für das virtualenv unter Linux hinzugefuegt.
Beim ersten run bin ich über die Datenbank gestolopert. alembic erstellt den instance-Ordner leider nicht.. daher der instance-Ordner mit der .gitkeep-Datei.